### PR TITLE
Fixing sdirs setting where variable isn't used

### DIFF
--- a/bashmarks.sh
+++ b/bashmarks.sh
@@ -25,7 +25,7 @@ fi
 touch $SDIRS
 
 function __unset_dirs {
-	eval `sed -e 's/export/unset/' -e 's/=.*/;/' ~/.sdirs | xargs`
+	eval `sed -e 's/export/unset/' -e 's/=.*/;/' $SDIRS | xargs`
 }
 
 # save current directory to bookmarks


### PR DESCRIPTION
If you're using a custom SDIRS the `__unset_dirs` function breaks since it isn't using the variable.